### PR TITLE
Use input step in deployment pipeline

### DIFF
--- a/buildkite/dev-deploy-pipeline.yml
+++ b/buildkite/dev-deploy-pipeline.yml
@@ -1,28 +1,4 @@
 steps:
-  - input: "Deploy"
-    fields:
-      - select: "Deploy whole app or only backend?"
-        key: "deploy"
-        required: true
-        default: "all"
-        options:
-          - label: "Whole app"
-            value: "all"
-          - label: "Hintr only"
-            value: "hintr"
-
-      - text: "Hint branch to deploy"
-        key: "hint-branch"
-        required: true
-        default: "master"
-
-      - text: "Hintr branch to deploy"
-        key: "hintr-branch"
-        required: true
-        default: "master"
-
-  - wait
-
   - label: ":rocket: preview"
     command: |
       DEPLOY=$(buildkite-agent meta-data get deploy)

--- a/buildkite/dev-deploy-pipeline.yml
+++ b/buildkite/dev-deploy-pipeline.yml
@@ -3,12 +3,35 @@ env:
   HINT_BRANCH: "${HINT_BRANCH:-master}"
   DEPLOY: "${DEPLOY:-all}"
 
-
 steps:
+  - input: "Deploy"
+    fields:
+      - select: "Deploy level"
+        key: "deploy"
+        hint: "Deploy whole app or only backend?"
+        required: true
+        default: "all"
+        options:
+          - label: "All components"
+            value: "all"
+          - label: "R backend only"
+            value: "hintr"
+
+      - text: "hint branch"
+        key: "hint-branch"
+        hint: "What hint branch to deploy?"
+        required: true
+        default: "master"
+
+      - text: "hintr branch"
+        key: "hintr-branch"
+        hint: "What hintr branch to deploy?"
+        required: true
+        default: "master"
+
   - label: ":rocket: dev"
-    command: >- 
-      ssh -i ~/.ssh/id_hiv -oStrictHostKeyChecking=accept-new vagrant@naomi-dev.dide.ic.ac.uk 
-      './clean-and-deploy-naomi.sh --hintr-branch=$HINTR_BRANCH --hint-branch=$HINT_BRANCH $DEPLOY'
+    command: >-
+      ssh -i ~/.ssh/id_hiv -oStrictHostKeyChecking=accept-new vagrant@naomi-dev.dide.ic.ac.uk
+      './clean-and-deploy-naomi.sh --hintr-branch=$(buildkite-agent meta-data get hintr-branch) --hint-branch=$(buildkite-agent meta-data get hint-branch) $(buildkite-agent meta-data get deploy)'
     agents:
       queue: "hint-deploy"
-

--- a/buildkite/dev-deploy-pipeline.yml
+++ b/buildkite/dev-deploy-pipeline.yml
@@ -1,37 +1,34 @@
-env:
-  HINTR_BRANCH: "${HINTR_BRANCH:-master}"
-  HINT_BRANCH: "${HINT_BRANCH:-master}"
-  DEPLOY: "${DEPLOY:-all}"
-
 steps:
   - input: "Deploy"
     fields:
-      - select: "Deploy level"
+      - select: "Deploy whole app or only backend?"
         key: "deploy"
-        hint: "Deploy whole app or only backend?"
         required: true
         default: "all"
         options:
-          - label: "All components"
+          - label: "Whole app"
             value: "all"
-          - label: "R backend only"
+          - label: "Hintr only"
             value: "hintr"
 
-      - text: "hint branch"
+      - text: "Hint branch to deploy"
         key: "hint-branch"
-        hint: "What hint branch to deploy?"
         required: true
         default: "master"
 
-      - text: "hintr branch"
+      - text: "Hintr branch to deploy"
         key: "hintr-branch"
-        hint: "What hintr branch to deploy?"
         required: true
         default: "master"
 
-  - label: ":rocket: dev"
-    command: >-
-      ssh -i ~/.ssh/id_hiv -oStrictHostKeyChecking=accept-new vagrant@naomi-dev.dide.ic.ac.uk
-      './clean-and-deploy-naomi.sh --hintr-branch=$(buildkite-agent meta-data get hintr-branch) --hint-branch=$(buildkite-agent meta-data get hint-branch) $(buildkite-agent meta-data get deploy)'
+  - wait
+
+  - label: ":rocket: preview"
+    command: |
+      DEPLOY=$(buildkite-agent meta-data get deploy)
+      HINT_BRANCH=$(buildkite-agent meta-data get hint-branch)
+      HINTR_BRANCH=$(buildkite-agent meta-data get hintr-branch)
+      ssh -i ~/.ssh/id_hiv -oStrictHostKeyChecking=accept-new vagrant@naomi-dev.dide.ic.ac.uk \
+        "./clean-and-deploy-naomi.sh --hintr-branch=$$HINTR_BRANCH --hint-branch=$$HINT_BRANCH $$DEPLOY"
     agents:
       queue: "hint-deploy"

--- a/buildkite/dev-deploy-pipeline.yml
+++ b/buildkite/dev-deploy-pipeline.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: ":rocket: preview"
+  - label: ":rocket: Dev"
     command: |
       DEPLOY=$(buildkite-agent meta-data get deploy)
       HINT_BRANCH=$(buildkite-agent meta-data get hint-branch)

--- a/buildkite/preview-deploy-pipeline.yml
+++ b/buildkite/preview-deploy-pipeline.yml
@@ -1,13 +1,34 @@
-env:
-  HINTR_BRANCH: "${HINTR_BRANCH:-master}"
-  HINT_BRANCH: "${HINT_BRANCH:-master}"
-  DEPLOY: "${DEPLOY:-all}"
-
-
 steps:
+  - input: "Deploy"
+    fields:
+      - select: "Deploy whole app or only backend?"
+        key: "deploy"
+        required: true
+        default: "all"
+        options:
+          - label: "Whole app"
+            value: "all"
+          - label: "Hintr only"
+            value: "hintr"
+
+      - text: "Hint branch to deploy"
+        key: "hint-branch"
+        required: true
+        default: "master"
+
+      - text: "Hintr branch to deploy"
+        key: "hintr-branch"
+        required: true
+        default: "master"
+
+  - wait
+
   - label: ":rocket: preview"
-    command: >-
-      ssh -i ~/.ssh/id_hiv -oStrictHostKeyChecking=accept-new vagrant@naomi-preview.dide.ic.ac.uk 
-      './clean-and-deploy-naomi.sh --hintr-branch=$HINTR_BRANCH --hint-branch=$HINT_BRANCH $DEPLOY'
+    command: |
+      DEPLOY=$(buildkite-agent meta-data get deploy)
+      HINT_BRANCH=$(buildkite-agent meta-data get hint-branch)
+      HINTR_BRANCH=$(buildkite-agent meta-data get hintr-branch)
+      ssh -i ~/.ssh/id_hiv -oStrictHostKeyChecking=accept-new vagrant@naomi-preview.dide.ic.ac.uk \
+        "./clean-and-deploy-naomi.sh --hintr-branch=$$HINTR_BRANCH --hint-branch=$$HINT_BRANCH $$DEPLOY"
     agents:
       queue: "hint-deploy"

--- a/buildkite/preview-deploy-pipeline.yml
+++ b/buildkite/preview-deploy-pipeline.yml
@@ -1,29 +1,5 @@
 steps:
-  - input: "Deploy"
-    fields:
-      - select: "Deploy whole app or only backend?"
-        key: "deploy"
-        required: true
-        default: "all"
-        options:
-          - label: "Whole app"
-            value: "all"
-          - label: "Hintr only"
-            value: "hintr"
-
-      - text: "Hint branch to deploy"
-        key: "hint-branch"
-        required: true
-        default: "master"
-
-      - text: "Hintr branch to deploy"
-        key: "hintr-branch"
-        required: true
-        default: "master"
-
-  - wait
-
-  - label: ":rocket: preview"
+  - label: ":rocket: Preview"
     command: |
       DEPLOY=$(buildkite-agent meta-data get deploy)
       HINT_BRANCH=$(buildkite-agent meta-data get hint-branch)

--- a/buildkite/production-deploy-pipeline.yml
+++ b/buildkite/production-deploy-pipeline.yml
@@ -1,29 +1,5 @@
 steps:
-  - input: "Deploy"
-    fields:
-      - select: "Deploy whole app or only backend?"
-        key: "deploy"
-        required: true
-        default: "all"
-        options:
-          - label: "Whole app"
-            value: "all"
-          - label: "Hintr only"
-            value: "hintr"
-
-      - text: "Hint branch to deploy"
-        key: "hint-branch"
-        required: true
-        default: "master"
-
-      - text: "Hintr branch to deploy"
-        key: "hintr-branch"
-        required: true
-        default: "master"
-
-  - wait
-
-  - label: ":rocket: preview"
+  - label: ":rocket: Production"
     command: |
       DEPLOY=$(buildkite-agent meta-data get deploy)
       HINT_BRANCH=$(buildkite-agent meta-data get hint-branch)

--- a/buildkite/production-deploy-pipeline.yml
+++ b/buildkite/production-deploy-pipeline.yml
@@ -1,14 +1,34 @@
-env:
-  HINTR_BRANCH: "${HINTR_BRANCH:-master}"
-  HINT_BRANCH: "${HINT_BRANCH:-master}"
-  DEPLOY: "${DEPLOY:-all}"
-
-
 steps:
-  - label: ":rocket: production"
-    command: >-
-      ssh -i ~/.ssh/id_hiv -oStrictHostKeyChecking=accept-new vagrant@naomi.dide.ic.ac.uk 
-      './clean-and-deploy-naomi.sh --hintr-branch=$HINTR_BRANCH --hint-branch=$HINT_BRANCH $DEPLOY'
+  - input: "Deploy"
+    fields:
+      - select: "Deploy whole app or only backend?"
+        key: "deploy"
+        required: true
+        default: "all"
+        options:
+          - label: "Whole app"
+            value: "all"
+          - label: "Hintr only"
+            value: "hintr"
+
+      - text: "Hint branch to deploy"
+        key: "hint-branch"
+        required: true
+        default: "master"
+
+      - text: "Hintr branch to deploy"
+        key: "hintr-branch"
+        required: true
+        default: "master"
+
+  - wait
+
+  - label: ":rocket: preview"
+    command: |
+      DEPLOY=$(buildkite-agent meta-data get deploy)
+      HINT_BRANCH=$(buildkite-agent meta-data get hint-branch)
+      HINTR_BRANCH=$(buildkite-agent meta-data get hintr-branch)
+      ssh -i ~/.ssh/id_hiv -oStrictHostKeyChecking=accept-new vagrant@naomi.dide.ic.ac.uk \
+        "./clean-and-deploy-naomi.sh --hintr-branch=$$HINTR_BRANCH --hint-branch=$$HINT_BRANCH $$DEPLOY"
     agents:
       queue: "hint-deploy"
-

--- a/buildkite/staging-deploy-pipeline.yml
+++ b/buildkite/staging-deploy-pipeline.yml
@@ -1,29 +1,5 @@
 steps:
-  - input: "Deploy"
-    fields:
-      - select: "Deploy whole app or only backend?"
-        key: "deploy"
-        required: true
-        default: "all"
-        options:
-          - label: "Whole app"
-            value: "all"
-          - label: "Hintr only"
-            value: "hintr"
-
-      - text: "Hint branch to deploy"
-        key: "hint-branch"
-        required: true
-        default: "master"
-
-      - text: "Hintr branch to deploy"
-        key: "hintr-branch"
-        required: true
-        default: "master"
-
-  - wait
-
-  - label: ":rocket: preview"
+  - label: ":rocket: Staging"
     command: |
       DEPLOY=$(buildkite-agent meta-data get deploy)
       HINT_BRANCH=$(buildkite-agent meta-data get hint-branch)

--- a/buildkite/staging-deploy-pipeline.yml
+++ b/buildkite/staging-deploy-pipeline.yml
@@ -1,13 +1,34 @@
-env:
-  HINTR_BRANCH: "${HINTR_BRANCH:-master}"
-  HINT_BRANCH: "${HINT_BRANCH:-master}"
-  DEPLOY: "${DEPLOY:-all}"
-
-
 steps:
-  - label: ":rocket: staging"
-    command: >-
-      ssh -i ~/.ssh/id_hiv -oStrictHostKeyChecking=accept-new vagrant@naomi-staging.dide.ic.ac.uk 
-      './clean-and-deploy-naomi.sh --hintr-branch=$HINTR_BRANCH --hint-branch=$HINT_BRANCH $DEPLOY'
+  - input: "Deploy"
+    fields:
+      - select: "Deploy whole app or only backend?"
+        key: "deploy"
+        required: true
+        default: "all"
+        options:
+          - label: "Whole app"
+            value: "all"
+          - label: "Hintr only"
+            value: "hintr"
+
+      - text: "Hint branch to deploy"
+        key: "hint-branch"
+        required: true
+        default: "master"
+
+      - text: "Hintr branch to deploy"
+        key: "hintr-branch"
+        required: true
+        default: "master"
+
+  - wait
+
+  - label: ":rocket: preview"
+    command: |
+      DEPLOY=$(buildkite-agent meta-data get deploy)
+      HINT_BRANCH=$(buildkite-agent meta-data get hint-branch)
+      HINTR_BRANCH=$(buildkite-agent meta-data get hintr-branch)
+      ssh -i ~/.ssh/id_hiv -oStrictHostKeyChecking=accept-new vagrant@naomi-staging.dide.ic.ac.uk \
+        "./clean-and-deploy-naomi.sh --hintr-branch=$$HINTR_BRANCH --hint-branch=$$HINT_BRANCH $$DEPLOY"
     agents:
       queue: "hint-deploy"


### PR DESCRIPTION
This will update the deployment pipelines to instead use an input step instead of env vars. Should be a bit of a nicer UI to use. To test it run, try a deployment with branch `mrc-3877` on any of dev, preview or staging